### PR TITLE
Fix Json parse error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const API_TOKEN = process.env['API_TOKEN'];
 const settings = require('./settings.json');
 
 exports.handler = async (event) => {
-  const gitHubBody = JSON.parse(event.body);
+  const gitHubBody = event.body;
 
   const gitHub = {
     event: event.headers['X-GitHub-Event'],


### PR DESCRIPTION
## 概要

GitHubの通知をフィルターしてslackに流したいと思い、探していたところ[GitHub のメンションを Slack へ通知する](https://qiita.com/hkusu/items/a899e51bdd260ab908d7)の記事を見つけて使わせてもらいました！とても助かりました 👍 
ただそのまま利用するとこんな感じでJsonのパースエラーが出ました

```
{
    "errorMessage": "Unexpected token o in JSON at position 1",
    "errorType": "SyntaxError",
    "stackTrace": [
        "JSON.parse (<anonymous>)",
        "exports.handler (/var/task/index.js:6:27)"
    ]
}
```